### PR TITLE
Fix: Handle binary stream correctly for GPG key import

### DIFF
--- a/install_docker_ubuntu.py
+++ b/install_docker_ubuntu.py
@@ -6,6 +6,7 @@ import os
 import sys
 import shutil
 import time
+import io
 
 # --- Configuration ---
 VERIFY_INSTALLATION = True
@@ -173,7 +174,7 @@ def main():
     # It's better to let `gpg` handle the input as a stream of bytes.
     if not run_command(
         ["gpg", "--dearmor", "-o", gpg_key_path],
-        input_stream=curl_result.stdout, # stdout is bytes due to text=False in curl command
+        input_stream=io.BytesIO(curl_result.stdout), # Wrap bytes in BytesIO for file-like object
         check=True, # Exit if gpg fails
         capture_output=True # To log any potential stderr from gpg
     ):


### PR DESCRIPTION
Resolved an AttributeError in `install_docker_ubuntu.py` that occurred during the GPG key import process. The `curl` command, when fetching the GPG key with `text=False`, produces bytes output. This was incorrectly passed directly as `input_stream` to the `gpg --dearmor` command.

The `subprocess.run` function expects a file-like object for its `stdin` when `input_stream` is used in this manner. This commit fixes the issue by wrapping `curl_result.stdout` (the bytes output) in an `io.BytesIO` object, providing the necessary file-like interface.

This ensures that the binary GPG key data is correctly piped from `curl` to `gpg` without error.